### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ gorevel
 
 4. 默认添加管理员账号admin 密码123。
 
-###Requirements
+### Requirements
 
 - Go1.2+
 
@@ -25,7 +25,7 @@ gorevel
 - github.com/robfig/go-cache
 - github.com/robfig/gomemcache/memcache
 
-###Install
+### Install
 
     $ git clone git://github.com/goofcc/gorevel.git
     $ cd gorevel


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
